### PR TITLE
don't dealloc null layout, fix build without file-io feature

### DIFF
--- a/openjp2-rs/Cargo.lock
+++ b/openjp2-rs/Cargo.lock
@@ -534,7 +534,7 @@ checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "openjp2"
-version = "0.6.2"
+version = "0.6.1"
 dependencies = [
  "bitflags 1.3.2",
  "byteorder",

--- a/openjp2-rs/Cargo.toml
+++ b/openjp2-rs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "openjp2"
 authors = ["Robert G. Jakabosky <rjakabosky+neopallium@neoawareness.com>"]
-version = "0.6.2"
+version = "0.6.1"
 license = "BSD-2-Clause"
 description = "Rust port of Openjpeg."
 repository = "https://github.com/Neopallium/openjp2"

--- a/openjp2-rs/Cargo.toml
+++ b/openjp2-rs/Cargo.toml
@@ -35,7 +35,7 @@ smallvec = "1.13"
 
 [features]
 default = ["file-io", "c_api"]
-
+std = []
 file-io = ["libc"]
 
 # FOR INTERNAL TESTING PURPOSES ONLY

--- a/openjp2-rs/src/codec.rs
+++ b/openjp2-rs/src/codec.rs
@@ -38,6 +38,7 @@ use super::consts::*;
 use super::types::*;
 
 use super::event::*;
+#[cfg(feature = "file-io")]
 use super::fprintf::StringWriter;
 
 pub(crate) enum CodecFormat {

--- a/openjp2-rs/src/j2k.rs
+++ b/openjp2-rs/src/j2k.rs
@@ -15,7 +15,9 @@ use super::malloc::*;
 
 use bitflags::bitflags;
 
+#[cfg(feature = "file-io")]
 mod dump;
+#[cfg(feature = "file-io")]
 pub(crate) use dump::*;
 
 bitflags! {

--- a/openjp2-rs/src/malloc.rs
+++ b/openjp2-rs/src/malloc.rs
@@ -52,13 +52,72 @@ pub(crate) fn strlen(s: *const i8) -> usize {
   }
 }
 
-#[cfg(any(feature = "c_api", feature = "test_malloc"))]
+/// Header-based allocator for builds without C FFI (`c_api` / `test_malloc`).
+/// Prepends each allocation with a size so `opj_free` can reconstruct the `Layout`.
+#[cfg(not(any(feature = "c_api", feature = "test_malloc")))]
+mod header_alloc {
+  use std::alloc::{self, Layout};
+
+  // Align header to 16 bytes so the returned pointer keeps reasonable alignment.
+  const HEADER: usize = 16;
+
+  fn layout_for(size: usize) -> Layout {
+    Layout::from_size_align(size + HEADER, HEADER).expect("invalid alloc layout")
+  }
+
+  pub fn malloc(size: usize) -> *mut core::ffi::c_void {
+    unsafe {
+      let raw = alloc::alloc(layout_for(size));
+      if raw.is_null() {
+        return core::ptr::null_mut();
+      }
+      *(raw as *mut usize) = size;
+      raw.add(HEADER) as *mut core::ffi::c_void
+    }
+  }
+
+  pub fn calloc(total: usize) -> *mut core::ffi::c_void {
+    unsafe {
+      let raw = alloc::alloc_zeroed(layout_for(total));
+      if raw.is_null() {
+        return core::ptr::null_mut();
+      }
+      *(raw as *mut usize) = total;
+      raw.add(HEADER) as *mut core::ffi::c_void
+    }
+  }
+
+  pub fn realloc(ptr: *mut core::ffi::c_void, new_size: usize) -> *mut core::ffi::c_void {
+    unsafe {
+      let old_raw = (ptr as *mut u8).sub(HEADER);
+      let old_size = *(old_raw as *const usize);
+      let new_raw = alloc::realloc(old_raw, layout_for(old_size), new_size + HEADER);
+      if new_raw.is_null() {
+        return core::ptr::null_mut();
+      }
+      *(new_raw as *mut usize) = new_size;
+      new_raw.add(HEADER) as *mut core::ffi::c_void
+    }
+  }
+
+  pub fn free(ptr: *mut core::ffi::c_void) {
+    unsafe {
+      let raw = (ptr as *mut u8).sub(HEADER);
+      let size = *(raw as *const usize);
+      alloc::dealloc(raw, layout_for(size));
+    }
+  }
+}
+
 pub(crate) fn opj_malloc(mut size: usize) -> *mut core::ffi::c_void {
   if size == 0 {
     /* prevent implementation defined behavior of malloc */
     return core::ptr::null_mut::<core::ffi::c_void>();
   }
-  unsafe { malloc(size) }
+  #[cfg(any(feature = "c_api", feature = "test_malloc"))]
+  { unsafe { malloc(size) } }
+  #[cfg(not(any(feature = "c_api", feature = "test_malloc")))]
+  { header_alloc::malloc(size) }
 }
 
 #[cfg(feature = "test_malloc")]
@@ -171,13 +230,15 @@ pub(crate) fn opj_alloc_type<T>() -> *mut T {
   }
 }
 
-#[cfg(any(feature = "c_api", feature = "test_malloc"))]
 pub(crate) fn opj_calloc(mut num: usize, mut size: usize) -> *mut core::ffi::c_void {
   if num == 0 || size == 0 {
     /* prevent implementation defined behavior of calloc */
     return core::ptr::null_mut::<core::ffi::c_void>();
   }
-  unsafe { calloc(num, size) }
+  #[cfg(any(feature = "c_api", feature = "test_malloc"))]
+  { unsafe { calloc(num, size) } }
+  #[cfg(not(any(feature = "c_api", feature = "test_malloc")))]
+  { header_alloc::calloc(num * size) }
 }
 
 pub(crate) fn opj_calloc_type<T>() -> *mut T {
@@ -254,7 +315,6 @@ pub(crate) fn opj_calloc_type_array<T>(num: usize) -> *mut T {
   }
 }
 
-#[cfg(any(feature = "c_api", feature = "test_malloc"))]
 pub(crate) fn opj_realloc(
   mut ptr: *mut core::ffi::c_void,
   mut new_size: usize,
@@ -264,7 +324,13 @@ pub(crate) fn opj_realloc(
     /* prevent implementation defined behavior of realloc */
     return core::ptr::null_mut::<core::ffi::c_void>();
   }
-  unsafe { realloc(ptr, new_size) }
+  if ptr.is_null() {
+    return opj_malloc(new_size);
+  }
+  #[cfg(any(feature = "c_api", feature = "test_malloc"))]
+  { unsafe { realloc(ptr, new_size) } }
+  #[cfg(not(any(feature = "c_api", feature = "test_malloc")))]
+  { header_alloc::realloc(ptr, new_size) }
 }
 
 pub(crate) fn opj_realloc_type_array<T>(mut ptr: *mut T, old_num: usize, mut num: usize) -> *mut T {
@@ -300,13 +366,14 @@ pub(crate) fn opj_realloc_type_array<T>(mut ptr: *mut T, old_num: usize, mut num
   }
 }
 
-#[cfg(any(feature = "c_api", feature = "test_malloc"))]
 pub(crate) fn opj_free(mut ptr: *mut core::ffi::c_void) {
-  unsafe {
-    if !ptr.is_null() {
-      free(ptr);
-    }
+  if ptr.is_null() {
+    return;
   }
+  #[cfg(any(feature = "c_api", feature = "test_malloc"))]
+  { unsafe { free(ptr) } }
+  #[cfg(not(any(feature = "c_api", feature = "test_malloc")))]
+  { header_alloc::free(ptr) }
 }
 
 pub(crate) fn opj_free_type<T>(mut ptr: *mut T) {

--- a/openjp2-rs/src/malloc.rs
+++ b/openjp2-rs/src/malloc.rs
@@ -1,6 +1,7 @@
 #[cfg(not(any(feature = "c_api", feature = "test_malloc")))]
 use std::alloc::{alloc, alloc_zeroed, dealloc, Layout};
 
+#[cfg(any(feature = "c_api", feature = "test_malloc"))]
 extern "C" {
 
   fn malloc(_: usize) -> *mut core::ffi::c_void;
@@ -51,6 +52,7 @@ pub(crate) fn strlen(s: *const i8) -> usize {
   }
 }
 
+#[cfg(any(feature = "c_api", feature = "test_malloc"))]
 pub(crate) fn opj_malloc(mut size: usize) -> *mut core::ffi::c_void {
   if size == 0 {
     /* prevent implementation defined behavior of malloc */
@@ -169,6 +171,7 @@ pub(crate) fn opj_alloc_type<T>() -> *mut T {
   }
 }
 
+#[cfg(any(feature = "c_api", feature = "test_malloc"))]
 pub(crate) fn opj_calloc(mut num: usize, mut size: usize) -> *mut core::ffi::c_void {
   if num == 0 || size == 0 {
     /* prevent implementation defined behavior of calloc */
@@ -251,6 +254,7 @@ pub(crate) fn opj_calloc_type_array<T>(num: usize) -> *mut T {
   }
 }
 
+#[cfg(any(feature = "c_api", feature = "test_malloc"))]
 pub(crate) fn opj_realloc(
   mut ptr: *mut core::ffi::c_void,
   mut new_size: usize,
@@ -296,6 +300,7 @@ pub(crate) fn opj_realloc_type_array<T>(mut ptr: *mut T, old_num: usize, mut num
   }
 }
 
+#[cfg(any(feature = "c_api", feature = "test_malloc"))]
 pub(crate) fn opj_free(mut ptr: *mut core::ffi::c_void) {
   unsafe {
     if !ptr.is_null() {

--- a/openjp2-rs/src/stream.rs
+++ b/openjp2-rs/src/stream.rs
@@ -280,6 +280,16 @@ impl Seek for StreamInner {
 }
 
 impl Stream {
+  /// Create a read stream from any `Read + Seek` source (e.g. `Cursor<Vec<u8>>`).
+  /// Works without the `file-io` feature, making it suitable for WASM.
+  pub fn from_reader<R: Read + Seek + 'static>(reader: R, length: u64) -> Self {
+    Self {
+      m_inner: StreamInner::new_reader(super::consts::opj::OPJ_J2K_STREAM_CHUNK_SIZE as usize, reader),
+      m_stream_length: length,
+      m_byte_offset: 0,
+    }
+  }
+
   #[cfg(feature = "file-io")]
   pub fn new_file<P: AsRef<Path>>(path: P, buffer_size: usize, is_input: bool) -> io::Result<Self> {
     if is_input {

--- a/openjp2-rs/src/tcd.rs
+++ b/openjp2-rs/src/tcd.rs
@@ -1416,11 +1416,13 @@ fn opj_tcd_code_block_dec_allocate(mut p_code_block: *mut opj_tcd_cblk_dec_t) ->
       let mut l_chunks = (*p_code_block).chunks;
       let mut l_numchunksalloc = (*p_code_block).numchunksalloc;
       let mut i: OPJ_UINT32 = 0;
-      dealloc(
-        (*p_code_block).decoded_data as _,
-        (*p_code_block).decoded_data_layout,
-      );
-      (*p_code_block).decoded_data = core::ptr::null_mut::<OPJ_INT32>();
+      if !(*p_code_block).decoded_data.is_null() {
+        dealloc(
+          (*p_code_block).decoded_data as _,
+          (*p_code_block).decoded_data_layout,
+        );
+        (*p_code_block).decoded_data = core::ptr::null_mut::<OPJ_INT32>();
+      }
       memset(
         p_code_block as *mut core::ffi::c_void,
         0i32,
@@ -2484,11 +2486,13 @@ fn opj_tcd_code_block_dec_deallocate(mut p_precinct: *mut opj_tcd_precinct_t) {
           );
           (*l_code_block).chunks = core::ptr::null_mut::<opj_tcd_seg_data_chunk_t>()
         }
-        dealloc(
-          (*l_code_block).decoded_data as _,
-          (*l_code_block).decoded_data_layout,
-        );
-        (*l_code_block).decoded_data = core::ptr::null_mut::<OPJ_INT32>();
+        if !(*l_code_block).decoded_data.is_null() {
+          dealloc(
+            (*l_code_block).decoded_data as _,
+            (*l_code_block).decoded_data_layout,
+          );
+          (*l_code_block).decoded_data = core::ptr::null_mut::<OPJ_INT32>();
+        }
         l_code_block = l_code_block.offset(1);
         cblkno += 1;
       }

--- a/openjp2-rs/tests/rust_api.rs
+++ b/openjp2-rs/tests/rust_api.rs
@@ -1,0 +1,138 @@
+//! Integration tests using the safe Rust API (no C FFI).
+//!
+//! These tests exercise the pure-Rust allocator path when run with:
+//!   cargo test --no-default-features --test rust_api
+//!
+//! They also work with default features (c_api) for comparison:
+//!   cargo test --test rust_api
+
+use std::io::Cursor;
+
+use openjp2::*;
+
+/// Helper: decode Hadley_Crater.jp2 via the safe Rust API and return the image.
+fn decode_hadley_crater() -> Box<opj_image> {
+    let bytes = std::fs::read("samples/Hadley_Crater.jp2").expect("read sample file");
+    let len = bytes.len() as u64;
+    let cursor = Cursor::new(bytes);
+    let mut stream = Stream::from_reader(cursor, len);
+
+    let mut codec = Codec::new_decoder(OPJ_CODEC_JP2).expect("create decoder");
+    let mut params = opj_dparameters_t::default();
+    assert_eq!(codec.setup_decoder(&mut params), 1, "setup_decoder failed");
+
+    let mut image = codec.read_header(&mut stream).expect("read_header failed");
+    assert_eq!(codec.decode(&mut stream, &mut image), 1, "decode failed");
+    assert_eq!(
+        codec.end_decompress(&mut stream),
+        1,
+        "end_decompress failed"
+    );
+    image
+}
+
+#[test]
+fn decode_header_metadata() {
+    let image = decode_hadley_crater();
+
+    assert_eq!(image.x0, 0);
+    assert_eq!(image.y0, 0);
+    assert_eq!(image.x1, 1920);
+    assert_eq!(image.y1, 1088);
+    assert_eq!(image.numcomps, 3);
+    assert_eq!(image.color_space, OPJ_CLRSPC_SRGB);
+}
+
+#[test]
+fn decode_component_properties() {
+    let image = decode_hadley_crater();
+    let comps = image.comps().expect("components should be present");
+    assert_eq!(comps.len(), 3);
+
+    for (i, comp) in comps.iter().enumerate() {
+        assert_eq!(comp.w, 1920, "comp[{i}] width");
+        assert_eq!(comp.h, 1088, "comp[{i}] height");
+        assert_eq!(comp.prec, 8, "comp[{i}] precision");
+        assert_eq!(comp.sgnd, 0, "comp[{i}] signed");
+        assert_eq!(comp.dx, 1, "comp[{i}] dx");
+        assert_eq!(comp.dy, 1, "comp[{i}] dy");
+    }
+}
+
+#[test]
+fn decode_pixel_values() {
+    let image = decode_hadley_crater();
+    let comps = image.comps().expect("components");
+
+    // Reference pixel values verified against both c_api and pure-Rust paths.
+    // Format: [comp][position] where positions are:
+    //   top-left, top-right, bottom-left, bottom-right, center
+    let expected: [[i32; 5]; 3] = [
+        [142, 160, 89, 83, 72],  // R
+        [77, 123, 44, 44, 20],   // G
+        [28, 74, 8, 29, 0],      // B
+    ];
+
+    for (i, comp) in comps.iter().enumerate() {
+        let data = comp.data().expect("pixel data");
+        let w = comp.w as usize;
+        let h = comp.h as usize;
+
+        assert_eq!(data[0], expected[i][0], "comp[{i}] top-left");
+        assert_eq!(data[w - 1], expected[i][1], "comp[{i}] top-right");
+        assert_eq!(data[(h - 1) * w], expected[i][2], "comp[{i}] bottom-left");
+        assert_eq!(data[h * w - 1], expected[i][3], "comp[{i}] bottom-right");
+        assert_eq!(data[(h / 2) * w + w / 2], expected[i][4], "comp[{i}] center");
+    }
+}
+
+#[test]
+fn decode_from_bytes_matches_format_detection() {
+    let bytes = std::fs::read("samples/Hadley_Crater.jp2").expect("read sample file");
+    let format = openjp2::detect_format(&bytes).expect("detect format");
+    assert_eq!(format, J2KFormat::JP2);
+}
+
+#[test]
+fn decode_pixel_data_nonzero() {
+    // Verify the decoded image contains meaningful data (not all zeros).
+    let image = decode_hadley_crater();
+    let comps = image.comps().expect("components");
+
+    for (i, comp) in comps.iter().enumerate() {
+        let data = comp.data().expect("pixel data");
+        let nonzero_count = data.iter().filter(|&&v| v != 0).count();
+        let total = data.len();
+        // A real image should have a significant fraction of non-zero pixels
+        assert!(
+            nonzero_count > total / 4,
+            "comp[{}]: only {}/{} non-zero pixels — data may be corrupt",
+            i, nonzero_count, total
+        );
+    }
+}
+
+#[test]
+fn decode_reduced_resolution() {
+    let bytes = std::fs::read("samples/Hadley_Crater.jp2").expect("read sample file");
+    let len = bytes.len() as u64;
+    let cursor = Cursor::new(bytes);
+    let mut stream = Stream::from_reader(cursor, len);
+
+    let mut codec = Codec::new_decoder(OPJ_CODEC_JP2).expect("create decoder");
+    let mut params = opj_dparameters_t::default();
+    params.cp_reduce = 2; // Decode at 1/4 resolution
+    assert_eq!(codec.setup_decoder(&mut params), 1);
+
+    let mut image = codec.read_header(&mut stream).expect("read header");
+    assert_eq!(codec.decode(&mut stream, &mut image), 1);
+    assert_eq!(codec.end_decompress(&mut stream), 1);
+
+    let comps = image.comps().expect("components");
+    // At reduce=2, dimensions should be roughly 1/4 of original
+    for comp in comps.iter() {
+        assert!(comp.w > 0 && comp.w <= 1920 / 3, "reduced width={}", comp.w);
+        assert!(comp.h > 0 && comp.h <= 1088 / 3, "reduced height={}", comp.h);
+        assert!(comp.data().is_some(), "reduced resolution should have data");
+    }
+}


### PR DESCRIPTION
Without this patch, we get the following crash when using the mimalloc allocator:

```unsafe precondition(s) violated: Layout::from_size_align_unchecked requires that align is a power of 2 and the rounded-up allocation size does not exceed isize::MAX

This indicates a bug in the program. This Undefined Behavior check is optional, and cannot be relied on for safety.
stack backtrace:
   0: __rustc::rust_begin_unwind
             at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/std/src/panicking.rs:689:5
   1: core::panicking::panic_nounwind_fmt::runtime
             at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/core/src/panicking.rs:122:22
   2: core::panicking::panic_nounwind_fmt
             at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/core/src/intrinsics/mod.rs:2449:9
   3: core::alloc::layout::Layout::from_size_align_unchecked::precondition_check
             at /Users/pmarks/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/ub_checks.rs:73:21
   4: core::alloc::layout::Layout::from_size_align_unchecked
             at /Users/pmarks/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/ub_checks.rs:78:17
   5: __rustc::__rust_dealloc
             at ./crates/gg_gpu/src/main.rs:67:1
   6: dealloc
             at /Users/pmarks/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/src/rust/library/alloc/src/alloc.rs:115:14
   7: opj_tcd_code_block_dec_deallocate
             at /Users/pmarks/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/openjp2-0.6.1/src/tcd.rs:2510:9
   8: opj_tcd_free_tile
             at /Users/pmarks/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/openjp2-0.6.1/src/tcd.rs:2073:17
   9: drop
             at /Users/pmarks/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/openjp2-0.6.1/src/tcd.rs:37:5
  10: drop_in_place<openjp2::types::opj_tcd>
             at /Users/pmarks/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/ptr/mod.rs:805:1
  11: drop_in_place<openjp2::types::opj_j2k>
             at /Users/pmarks/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/ptr/mod.rs:805:1
  12: drop_in_place<openjp2::types::opj_jp2>
             at /Users/pmarks/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/ptr/mod.rs:805:1
  13: drop_in_place<openjp2::codec::CodecFormat>
             at /Users/pmarks/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/ptr/mod.rs:805:1
  14: drop_in_place<openjp2::codec::CodecType>
             at /Users/pmarks/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/ptr/mod.rs:805:1
  15: drop_in_place<openjp2::codec::Codec>
             at /Users/pmarks/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/ptr/mod.rs:805:1
  16: drop_in_place<alloc::boxed::Box<openjp2::codec::Codec, alloc::alloc::Global>>
             at /Users/pmarks/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/ptr/mod.rs:805:1
  17: opj_destroy_codec
             at /Users/pmarks/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/openjp2-0.6.1/src/openjpeg.rs:495:61
  18: drop
             at /Users/pmarks/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/jpeg2k-0.10.1/src/codec.rs:372:7
  19: drop_in_place<jpeg2k::codec::Codec>```