### PR TITLE
Guard null decoded buffers before deallocation

### DIFF
--- a/openjp2-rs/src/tcd.rs
+++ b/openjp2-rs/src/tcd.rs
@@ -1416,11 +1416,13 @@ fn opj_tcd_code_block_dec_allocate(mut p_code_block: *mut opj_tcd_cblk_dec_t) ->
       let mut l_chunks = (*p_code_block).chunks;
       let mut l_numchunksalloc = (*p_code_block).numchunksalloc;
       let mut i: OPJ_UINT32 = 0;
-      dealloc(
-        (*p_code_block).decoded_data as _,
-        (*p_code_block).decoded_data_layout,
-      );
-      (*p_code_block).decoded_data = core::ptr::null_mut::<OPJ_INT32>();
+      if !(*p_code_block).decoded_data.is_null() {
+        dealloc(
+          (*p_code_block).decoded_data as _,
+          (*p_code_block).decoded_data_layout,
+        );
+        (*p_code_block).decoded_data = core::ptr::null_mut::<OPJ_INT32>();
+      }
       memset(
         p_code_block as *mut core::ffi::c_void,
         0i32,
@@ -2484,11 +2486,13 @@ fn opj_tcd_code_block_dec_deallocate(mut p_precinct: *mut opj_tcd_precinct_t) {
           );
           (*l_code_block).chunks = core::ptr::null_mut::<opj_tcd_seg_data_chunk_t>()
         }
-        dealloc(
-          (*l_code_block).decoded_data as _,
-          (*l_code_block).decoded_data_layout,
-        );
-        (*l_code_block).decoded_data = core::ptr::null_mut::<OPJ_INT32>();
+        if !(*l_code_block).decoded_data.is_null() {
+          dealloc(
+            (*l_code_block).decoded_data as _,
+            (*l_code_block).decoded_data_layout,
+          );
+          (*l_code_block).decoded_data = core::ptr::null_mut::<OPJ_INT32>();
+        }
         l_code_block = l_code_block.offset(1);
         cblkno += 1;
       }


### PR DESCRIPTION
### Summary
- guard both decoded-codeblock deallocation sites against null pointers
- preserve the existing allocator implementation and feature behavior

### Evidence
- reproduces in RITK's JPEG 2000 differential suite on stable Rust as a NonNull precondition abort
- openjp2 nextest: 4/4 passed
- RITK's full suite exposed the broader allocator rewrite in PR #6 as an invalid-pointer regression, so this PR contains only the required guards

Closes #8